### PR TITLE
Fixes download/upload speed, #16.

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,11 +43,11 @@ function Stats (opts) {
       if (err && /is closed/.test(err.message)) return
       if (err) return self.emit('error', err)
 
-      archive.content.on('upload', function (buf) {
+      archive.on('upload', function (buf) {
         self.update({ uploadSpeed: uploadSpeed(buf.length) })
       })
 
-      archive.content.on('download', function (buf) {
+      archive.on('download', function (buf) {
         self.update({ downloadSpeed: downloadSpeed(buf.length) })
       })
 


### PR DESCRIPTION
`archive.content.on('download')` emits with `(block, buf)` so we were using `block.length` to measure speed. `archive.on('download')` just emits the data blocks, as previously expected.
